### PR TITLE
optionally preserve the order or ROIs in a zip

### DIFF
--- a/read_roi/_read_roi.py
+++ b/read_roi/_read_roi.py
@@ -297,13 +297,12 @@ def read_roi_file(fpath):
     return {name: roi}
 
 
-def read_roi_zip(zip_path,preserveOrder=False):
+def read_roi_zip(zip_path):
     """
     """
-    rois = {}
+    from collections import OrderedDict
+    rois = OrderedDict()
     zf = zipfile.ZipFile(zip_path)
     for n in zf.namelist():
         rois.update(read_roi_file(zf.open(n)))
-    if preserveOrder:
-        return [rois[x[:-4]] for x in zf.namelist()]
     return rois

--- a/read_roi/_read_roi.py
+++ b/read_roi/_read_roi.py
@@ -297,11 +297,13 @@ def read_roi_file(fpath):
     return {name: roi}
 
 
-def read_roi_zip(zip_path):
+def read_roi_zip(zip_path,preserveOrder=False):
     """
     """
     rois = {}
     zf = zipfile.ZipFile(zip_path)
     for n in zf.namelist():
         rois.update(read_roi_file(zf.open(n)))
+    if preserveOrder:
+        return [rois[x[:-4]] for x in zf.namelist()]
     return rois


### PR DESCRIPTION
Preserving the order of ROIs in a ZIP is important for my application, but returning ROIs as a dictionary loses this order. The zip file list contains the dictionary keys as file names in the preserved order. Since each list item in the returned list is a dict with 'name' key, no data is lost by returning a list over a dict. Making it optional preserves backward compatibility.