### PR TITLE
Implement counters for multi-point rois

### DIFF
--- a/read_roi/_read_roi.py
+++ b/read_roi/_read_roi.py
@@ -370,8 +370,9 @@ def read_roi_file(fpath):
 
     if version >= 227 and roi['type'] == 'point':
         # Get "point counters" (includes a "counter" and a "position" (slice, i.e. z position)
-        counters, positions = get_point_counters(data, hdr2Offset, n_coordinates, size)
-        if counters is not None:
+        tmp = get_point_counters(data, hdr2Offset, n_coordinates, size)
+        if tmp is not None:
+            counters, positions = tmp
             if counters:
                 roi.update(dict(counters=counters, slices=positions))
 

--- a/read_roi/test/data/multipoint.json
+++ b/read_roi/test/data/multipoint.json
@@ -1,6 +1,6 @@
 {
   "multipoint": {
-    "type": "freeroi",
+    "type": "point",
     "x": [
       149.6666717529297,
       139.3333282470703,

--- a/read_roi/test/data/point.json
+++ b/read_roi/test/data/point.json
@@ -1,6 +1,6 @@
 {
   "point": {
-    "type": "freeroi",
+    "type": "point",
     "x": [
       68.0
     ],
@@ -9,6 +9,8 @@
     ],
     "n": 1,
     "name": "point",
+	"counters": [0],
+	"slices": [1],
     "position": {
       "channel": 1,
       "slice": 1,

--- a/read_roi/test/test_read_roi.py
+++ b/read_roi/test/test_read_roi.py
@@ -34,7 +34,9 @@ def test_point():
     true_data = {'point': {'n': 1,
                            'name': 'point',
                            'position': {'channel': 1, 'frame': 1, 'slice': 1},
-                           'type': 'freeroi',
+                           'type': 'point',
+						   'slices': [1],
+						   'counters': [0],
                            'x': [68.0],
                            'y': [77.25]}}
 


### PR DESCRIPTION
This fork implements the "counters" for multi-point ROIs, i.e. it allows you to load the z coordinates of the points, which is quite important when working with 3D microscopy data.

The code had to be unfortunately restructured a bit to mirror the logic in the Java implementation at https://imagej.nih.gov/ij/developer/source/ij/io/RoiDecoder.java.html while still staying as close as possible to it. Note how, in RoiDecoder.java, control breaks out of the big switch statement (line 220) at line 297. Because Python has no switch / break and no way to jump out of nested ifs, the python implementation had a bug where point ROIs would incorrectly be assigned the default "freeroi" type. (The same bug would also occur for freehand type, see break at line 314).

Long story short, I wrapped the code that would be the switch body in Java in a python function extract_basic_roi_data() so that return can be used as a replacement for switch / break.