### PR TITLE
CI: Test on python 3.5 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ matrix:
     - language: python
       os: linux
       env:
+        - PYTHON_VERSION="3.5"
+    - language: python
+      os: linux
+      env:
         - PYTHON_VERSION="3.6"
     - language: python
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ matrix:
       os: linux
       env:
         - PYTHON_VERSION="3.7"
+    - language: python
+      os: linux
+      env:
+        - PYTHON_VERSION="3.8"
 
 install:
   - sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ rois = read_roi_zip(roi_zip_path)
 
 ## Requirements
 
-- Python 3.6 and above.
+- Python 3.5 and above.
 
 ## Install
 


### PR DESCRIPTION
Adds Python versions 3.5 and 3.8 to the Travis build matrix.