### PR TITLE
CI: Run tests in Travis venv instead of conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,21 +13,8 @@ matrix:
         - PYTHON_VERSION="3.7"
 
 install:
-  - sudo apt-get update
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - echo ". $HOME/miniconda/etc/profile.d/conda.sh" >> $HOME/.bashrc
-  - source $HOME/.bashrc
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda config --add channels conda-forge
-  - conda update -q conda
-  - conda info -a
-  - conda create -n conda_env python=$PYTHON_VERSION
-  - conda activate conda_env
-  - conda install nose
+  - pip install nose
+  - python setup.py install
 
 script:
-  - conda activate conda_env
-  - python setup.py install
   - nosetests -v -s .


### PR DESCRIPTION
We don't need a miniconda environment for this project, which has no dependencies. With this PR, we use the Python virtual environment which Travis provides for us and pip install nose into that instead of downloading miniconda and setting up a conda environment. This reduces the CI run time by 80% (from 90s to 18s per matrix entry).

Also moves the install operation to the install part of the CI build.