### PR TITLE
CI+DOC: Push coverage to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,8 @@ install:
 
 script:
   - coverage run --source read_roi --omit '*/*test*/*' -m nose -v -s .
+
+after_success:
+  - |
+    curl -s -S -L --connect-timeout 5 --retry 6 https://codecov.io/bash -o codecov-upload.sh || echo "Codecov script failed to download";
+    travis_retry bash codecov-upload.sh || echo "Codecov push failed";

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,21 +13,8 @@ matrix:
         - PYTHON_VERSION="3.7"
 
 install:
-  - sudo apt-get update
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - echo ". $HOME/miniconda/etc/profile.d/conda.sh" >> $HOME/.bashrc
-  - source $HOME/.bashrc
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda config --add channels conda-forge
-  - conda update -q conda
-  - conda info -a
-  - conda create -n conda_env python=$PYTHON_VERSION
-  - conda activate conda_env
-  - conda install nose
+  - pip install nose
+  - python setup.py install
 
 script:
-  - conda activate conda_env
-  - python setup.py install
   - nosetests -v -s .

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ matrix:
         - PYTHON_VERSION="3.7"
 
 install:
-  - pip install nose
+  - pip install nose coverage
   - python setup.py install
 
 script:
-  - nosetests -v -s .
+  - coverage run --source read_roi --omit '*/*test*/*' -m nose -v -s .

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # read-roi
 
-[![Build Status](https://travis-ci.com/hadim/read-roi.svg?branch=master)](https://travis-ci.com/hadim/read-roi)
 [![PyPI version](https://img.shields.io/pypi/v/read-roi.svg?maxAge=2591000)](https://pypi.org/project/read-roi/)
+[![Build Status](https://travis-ci.com/hadim/read-roi.svg?branch=master)](https://travis-ci.com/hadim/read-roi)
+[![codecov](https://codecov.io/gh/hadim/read-roi/branch/master/graph/badge.svg)](https://codecov.io/gh/hadim/read-roi)
 
 Read ROI files .zip or .roi generated with ImageJ. Code is largely inspired from : http://rsb.info.nih.gov/ij/developer/source/ij/io/RoiDecoder.java.html
 


### PR DESCRIPTION
- Record test coverage and push it to https://codecov.io/
- Adds badge showing coverage to README

You'll (@hadim) need to also go to https://codecov.io/gh/hadim/read-roi, sign in, and set up the repository (you just need to give codecov permission to access the repo through the github API).

Assumes PR #16 is merged.