### PR TITLE
Support either nose or nose2 as test runner

### DIFF
--- a/read_roi/test/test_read_roi.py
+++ b/read_roi/test/test_read_roi.py
@@ -2,7 +2,12 @@ import os
 import json
 
 from unittest import TestCase
-from nose.tools import nottest
+try:
+    from nose.tools import nottest
+except ImportError:
+    # Do-nothing decorator: ok when the test runner is nose2
+    def nottest(func):
+        return func
 
 import read_roi
 


### PR DESCRIPTION
See https://fedoraproject.org/wiki/Changes/DeprecateNose for some reasons not to rely on nose.

With this change, either nose (`nosetests`) or nose2 (`nose2`) can be used as the test runner, and the original nose does not need to be installed to run the tests.